### PR TITLE
Fix: Storage stats error

### DIFF
--- a/src/persyval/services/handlers/storage_root.py
+++ b/src/persyval/services/handlers/storage_root.py
@@ -9,6 +9,7 @@ from persyval.services.execution_queue.execution_queue import (
     HandlerArgsBase,
     HandlerFullArgs,
 )
+from persyval.services.handlers.shared.args_i_empty import ArgsIEmpty
 from persyval.services.handlers_base.handler_base import HandlerBase
 
 if TYPE_CHECKING:
@@ -65,6 +66,7 @@ class StorageRootIHandler(
                 self.execution_queue.put(
                     HandlerFullArgs(
                         command=Command.STORAGE_STATS,
+                        args=ArgsIEmpty(),
                     ),
                 )
 

--- a/src/persyval/services/handlers/storage_stats.py
+++ b/src/persyval/services/handlers/storage_stats.py
@@ -7,6 +7,7 @@ from persyval.services.handlers_base.handler_base import HandlerBase
 
 if TYPE_CHECKING:
     from persyval.services.commands.args_config import ArgsConfig
+    from persyval.services.handlers_base.handler_output import HandlerOutput
 
 
 class StorageStatsIHandler(
@@ -18,7 +19,7 @@ class StorageStatsIHandler(
     def _make_action(
         self,
         parsed_args: ArgsIEmpty,  # noqa: ARG002
-    ) -> None:
+    ) -> HandlerOutput | None:
         table = Table(title="Storage Stats", title_justify="left")
         table.add_column("Name")
         table.add_column("Amount")
@@ -30,3 +31,4 @@ class StorageStatsIHandler(
             )
 
         self.console.print(table)
+        return None


### PR DESCRIPTION
- Use ArgsIEmpty() to eliminate error when calling storage stats command.